### PR TITLE
Use `File.basename` when uploading files

### DIFF
--- a/lib/framed_uploader/uploader.rb
+++ b/lib/framed_uploader/uploader.rb
@@ -27,7 +27,7 @@ module FramedUploader
       filenames.each do |filename|
         s3_key = tmpl.expand({"company_id" => company_id,
                               "timestamp" => batch_timestamp,
-                              "filename" => filename}).path
+                              "filename" => File.basename(filename)}).path
 
         File.open(filename, 'rb') do |body|
           s3.put_object(bucket: bucket, key: s3_key, body: body)

--- a/lib/framed_uploader/version.rb
+++ b/lib/framed_uploader/version.rb
@@ -1,3 +1,3 @@
 module FramedUploader
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Without this, full file paths will be encoded into an S3 key, like
`%/tmp%/users.csv`, where we really just want the basename `users.csv`.

This likely did not come up during testing because files were uploaded
relative to the current directory (i.e. `framed-upload users.csv`),
as opposed to `/tmp/users.csv` for example.
